### PR TITLE
Remove any trailing slash from url

### DIFF
--- a/flask_redis.py
+++ b/flask_redis.py
@@ -33,7 +33,7 @@ def parse_url(url):
     """
     # Parse URL, make sure string is valid.
     try:
-        split = moves.urllib.parse.urlsplit(url)
+        split = moves.urllib.parse.urlsplit(url.rstrip('/'))
     except (AttributeError, TypeError) as e:
         raise ValueError('Malformed URL specified: {0}'.format(e))
     if split.scheme not in ['redis+socket', 'redis', 'file']:

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -101,5 +101,8 @@ def test_network_urls():
     actual = parse_url('redis://localhost/2')
     assert dict(host='localhost', db=2) == actual
 
+    actual = parse_url('redis://localhost/')
+    assert dict(host='localhost') == actual
+
     actual = parse_url('redis://localhost')
     assert dict(host='localhost') == actual


### PR DESCRIPTION
Sometimes redis urls are given with a trailing slash (such as on Redis To Go),
this allows these urls to parse.
